### PR TITLE
fix: Path Case for WAdapter lib

### DIFF
--- a/WThermostat/WBecaDevice.h
+++ b/WThermostat/WBecaDevice.h
@@ -4,8 +4,8 @@
 #include "Arduino.h"
 #include <ESP8266WiFi.h>
 #include <EEPROM.h>
-#include "../lib/WAdapter/Wadapter/WDevice.h"
-#include "../lib/WAdapter/Wadapter/WPage.h"
+#include "../lib/WAdapter/WAdapter/WDevice.h"
+#include "../lib/WAdapter/WAdapter/WPage.h"
 #include "WClock.h"
 
 const static char HTTP_SELECTED[] PROGMEM = "selected=\"selected\"";

--- a/WThermostat/WClock.h
+++ b/WThermostat/WClock.h
@@ -16,8 +16,8 @@
 #include <TimeLib.h>
 #include <WiFiUdp.h>
 
-#include "../lib/WAdapter/Wadapter/WDevice.h"
-#include "../lib/WAdapter/Wadapter/WNetwork.h"
+#include "../lib/WAdapter/WAdapter/WDevice.h"
+#include "../lib/WAdapter/WAdapter/WNetwork.h"
 #include "Arduino.h"
 
 const static char* DEFAULT_NTP_SERVER = "pool.ntp.org";

--- a/WThermostat/WLogDevice.h
+++ b/WThermostat/WLogDevice.h
@@ -4,7 +4,7 @@
 #include "Arduino.h"
 #include <ESP8266WiFi.h>
 #include <EEPROM.h>
-#include "../lib/WAdapter/Wadapter/WDevice.h"
+#include "../lib/WAdapter/WAdapter/WDevice.h"
 
 const char* LOG_MODE_SILENT  = "silent";
 const char* LOG_MODE_FATAL   = "fatal";


### PR DESCRIPTION
I just tried to get the software build, and was struggling due to missing files, which did not seem to be true! 
The imports for the WAdapter Lib have a "typo" e.g.: 
#include "../lib/WAdapter/W**a**dapter/WDevice.h"
to be: 
#include "../lib/WAdapter/W**A**dapter/WDevice.h"
I presume I'm the first trying to build with linux. :-D 
adding it here to help other newbies of Platform.Io and VScode. 