### PR TITLE
HomeAssistant minTempSet to 5°C

### DIFF
--- a/WThermostat/WBecaDevice.h
+++ b/WThermostat/WBecaDevice.h
@@ -56,7 +56,7 @@ const static char MQTT_HASS_AUTODISCOVERY_CLIMATE[]         PROGMEM = R"=====(
 "curr_temp_tpl":"{{value_json.temperature}}",
 "pl_on":true,
 "pl_off":false,
-"min_temp":"10",
+"min_temp":"5",
 "max_temp":"35",
 "temp_step":"%s",
 "modes":["heat","auto","off"]
@@ -90,7 +90,7 @@ const static char MQTT_HASS_AUTODISCOVERY_AIRCO[]         PROGMEM = R"=====(
 "hold_modes":["scheduler","manual","eco"],
 "pl_on":true,
 "pl_off":false,
-"min_temp":"10",
+"min_temp":"5",
 "max_temp":"35",
 "temp_step":"%s",
 "modes":["heat","cool","fan_only","off"]


### PR DESCRIPTION
Modified autodiscovery settings to let home-assistant set temperature down to 5°C

Partially solves https://github.com/fashberg/WThermostatBeca/issues/82